### PR TITLE
Eleven: request record audio permission for visualizer

### DIFF
--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -41,7 +41,7 @@
 
         <!-- Music visualizer -->
         <SwitchPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="music_visualization"
             android:title="@string/settings_show_music_visualization_title" />
 

--- a/src/com/cyanogenmod/eleven/ui/activities/HomeActivity.java
+++ b/src/com/cyanogenmod/eleven/ui/activities/HomeActivity.java
@@ -202,8 +202,9 @@ public class HomeActivity extends SlidingPanelActivity implements
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
 
-        getAudioPlayerFragment().setVisualizerVisible(hasFocus
-                && getCurrentPanel() == Panel.MusicPlayer);
+        if (getCurrentPanel() == Panel.MusicPlayer) {
+            getAudioPlayerFragment().setVisualizerVisible(hasFocus);
+        }
     }
 
     private void updateStatusBarColor() {

--- a/src/com/cyanogenmod/eleven/ui/activities/SettingsActivity.java
+++ b/src/com/cyanogenmod/eleven/ui/activities/SettingsActivity.java
@@ -105,7 +105,10 @@ public class SettingsActivity extends PreferenceActivity implements OnSharedPref
     @Override
     public void onSharedPreferenceChanged(SharedPreferences sharedPreferences,
              String key) {
-        if (key.equals(PreferenceUtils.SHAKE_TO_PLAY)) {
+        if (key.equals(PreferenceUtils.SHOW_VISUALIZER) &&
+                sharedPreferences.getBoolean(key, false) && !PreferenceUtils.canRecordAudio(this)) {
+            PreferenceUtils.requestRecordAudio(this);
+        } if (key.equals(PreferenceUtils.SHAKE_TO_PLAY)) {
             MusicUtils.setShakeToPlayEnabled(sharedPreferences.getBoolean(key, false));
         } else if (key.equals(PreferenceUtils.SHOW_ALBUM_ART_ON_LOCKSCREEN)) {
             MusicUtils.setShowAlbumArtOnLockscreen(sharedPreferences.getBoolean(key, true));

--- a/src/com/cyanogenmod/eleven/ui/fragments/AudioPlayerFragment.java
+++ b/src/com/cyanogenmod/eleven/ui/fragments/AudioPlayerFragment.java
@@ -713,7 +713,11 @@ public class AudioPlayerFragment extends Fragment implements ServiceConnection {
 
     public void setVisualizerVisible(boolean visible) {
         if (visible && PreferenceUtils.getInstance(getActivity()).getShowVisualizer()) {
-            mVisualizerView.setVisible(true);
+            if (PreferenceUtils.canRecordAudio(getActivity())) {
+                mVisualizerView.setVisible(true);
+            } else {
+                PreferenceUtils.requestRecordAudio(getActivity());
+            }
         } else {
             mVisualizerView.setVisible(false);
         }

--- a/src/com/cyanogenmod/eleven/utils/PreferenceUtils.java
+++ b/src/com/cyanogenmod/eleven/utils/PreferenceUtils.java
@@ -13,8 +13,11 @@
 
 package com.cyanogenmod.eleven.utils;
 
+import android.Manifest.permission;
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.preference.PreferenceManager;
@@ -83,6 +86,8 @@ public final class PreferenceUtils {
 
     // show/hide album art on lockscreen
     public static final String SHOW_ALBUM_ART_ON_LOCKSCREEN = "lockscreen_album_art";
+
+    private static final int PERMISSION_REQUEST_RECORD_AUDIO = 1;
 
     private static PreferenceUtils sInstance;
 
@@ -334,8 +339,19 @@ public final class PreferenceUtils {
         return mPreferences.getBoolean(SHOW_LYRICS, true);
     }
 
+    public static boolean canRecordAudio(Activity activity) {
+        return activity.checkSelfPermission(permission.RECORD_AUDIO) ==
+                PackageManager.PERMISSION_GRANTED;
+    }
+
+    public static void requestRecordAudio(Activity activity) {
+        activity.requestPermissions(
+                new String[] {permission.RECORD_AUDIO},
+                PERMISSION_REQUEST_RECORD_AUDIO);
+    }
+
     public boolean getShowVisualizer() {
-        return mPreferences.getBoolean(SHOW_VISUALIZER, true);
+        return mPreferences.getBoolean(SHOW_VISUALIZER, false);
     }
 
     public boolean getShakeToPlay() {


### PR DESCRIPTION
Visualizer needs audio recording permission.

* set visualizer to disabled by default
* ask for audio recording permission when visualizer is enabled
* fix a case where visualizer visibility would be set multiple times in a row
* if visualizer is enabled but audio recording permission is not granted
  ask for it when the audio player fragment gets focus

Change-Id: I2c175915cc686ce37e6e94d113e767a75ef68492