### PR TITLE
Eleven: Create one cursor per background task

### DIFF
--- a/src/com/cyanogenmod/eleven/loaders/AlbumLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/AlbumLoader.java
@@ -46,11 +46,6 @@ public class AlbumLoader extends SectionCreator.SimpleListLoader<Album> {
     private ArrayList<Album> mAlbumsList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private Cursor mCursor;
-
-    /**
      * Additional selection filter
      */
     protected Long mArtistId;
@@ -78,24 +73,24 @@ public class AlbumLoader extends SectionCreator.SimpleListLoader<Album> {
     @Override
     public List<Album> loadInBackground() {
         // Create the Cursor
-        mCursor = makeAlbumCursor(getContext(), mArtistId);
+        Cursor cursor = makeAlbumCursor(getContext(), mArtistId);
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the album id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the album name
-                final String albumName = mCursor.getString(1);
+                final String albumName = cursor.getString(1);
 
                 // Copy the artist name
-                final String artist = mCursor.getString(2);
+                final String artist = cursor.getString(2);
 
                 // Copy the number of songs
-                final int songCount = mCursor.getInt(3);
+                final int songCount = cursor.getInt(3);
 
                 // Copy the release year
-                final String year = mCursor.getString(4);
+                final String year = cursor.getString(4);
 
                 // as per designer's request, don't show unknown albums
                 if (MediaStore.UNKNOWN_STRING.equals(albumName)) {
@@ -105,18 +100,18 @@ public class AlbumLoader extends SectionCreator.SimpleListLoader<Album> {
                 // Create a new album
                 final Album album = new Album(id, albumName, artist, songCount, year);
 
-                if (mCursor instanceof SortedCursor) {
-                    album.mBucketLabel = (String)((SortedCursor)mCursor).getExtraData();
+                if (cursor instanceof SortedCursor) {
+                    album.mBucketLabel = (String)((SortedCursor) cursor).getExtraData();
                 }
 
                 // Add everything up
                 mAlbumsList.add(album);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
 
         return mAlbumsList;

--- a/src/com/cyanogenmod/eleven/loaders/AlbumSongLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/AlbumSongLoader.java
@@ -40,11 +40,6 @@ public class AlbumSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
     private final ArrayList<Song> mSongList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private Cursor mCursor;
-
-    /**
      * The Id of the album the songs belong to.
      */
     private final Long mAlbumID;
@@ -66,42 +61,42 @@ public class AlbumSongLoader extends WrappedAsyncTaskLoader<List<Song>> {
     @Override
     public List<Song> loadInBackground() {
         // Create the Cursor
-        mCursor = makeAlbumSongCursor(getContext(), mAlbumID);
+        Cursor cursor = makeAlbumSongCursor(getContext(), mAlbumID);
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the song Id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the song name
-                final String songName = mCursor.getString(1);
+                final String songName = cursor.getString(1);
 
                 // Copy the artist name
-                final String artist = mCursor.getString(2);
+                final String artist = cursor.getString(2);
 
                 // Copy the album name
-                final String album = mCursor.getString(3);
+                final String album = cursor.getString(3);
 
                 // Copy the duration
-                final long duration = mCursor.getLong(4);
+                final long duration = cursor.getLong(4);
 
                 // Make the duration label
                 final int seconds = (int) (duration / 1000);
 
                 // Grab the Song Year
-                final int year = mCursor.getInt(5);
+                final int year = cursor.getInt(5);
 
                 // Create a new song
                 final Song song = new Song(id, songName, artist, album, mAlbumID, seconds, year);
 
                 // Add everything up
                 mSongList.add(song);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
         return mSongList;
     }

--- a/src/com/cyanogenmod/eleven/loaders/ArtistLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/ArtistLoader.java
@@ -44,11 +44,6 @@ public class ArtistLoader extends SectionCreator.SimpleListLoader<Artist> {
     private ArrayList<Artist> mArtistsList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private Cursor mCursor;
-
-    /**
      * Constructor of <code>ArtistLoader</code>
      *
      * @param context The {@link Context} to use
@@ -63,21 +58,21 @@ public class ArtistLoader extends SectionCreator.SimpleListLoader<Artist> {
     @Override
     public List<Artist> loadInBackground() {
         // Create the Cursor
-        mCursor = makeArtistCursor(getContext());
+        Cursor cursor = makeArtistCursor(getContext());
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the artist id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the artist name
-                final String artistName = mCursor.getString(1);
+                final String artistName = cursor.getString(1);
 
                 // Copy the number of albums
-                final int albumCount = mCursor.getInt(2);
+                final int albumCount = cursor.getInt(2);
 
                 // Copy the number of songs
-                final int songCount = mCursor.getInt(3);
+                final int songCount = cursor.getInt(3);
 
                 // as per designer's request, don't show unknown artist
                 if (MediaStore.UNKNOWN_STRING.equals(artistName)) {
@@ -87,17 +82,17 @@ public class ArtistLoader extends SectionCreator.SimpleListLoader<Artist> {
                 // Create a new artist
                 final Artist artist = new Artist(id, artistName, songCount, albumCount);
 
-                if (mCursor instanceof SortedCursor) {
-                    artist.mBucketLabel = (String)((SortedCursor)mCursor).getExtraData();
+                if (cursor instanceof SortedCursor) {
+                    artist.mBucketLabel = (String)((SortedCursor) cursor).getExtraData();
                 }
 
                 mArtistsList.add(artist);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
 
         return mArtistsList;

--- a/src/com/cyanogenmod/eleven/loaders/LastAddedLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/LastAddedLoader.java
@@ -40,11 +40,6 @@ public class LastAddedLoader extends SectionCreator.SimpleListLoader<Song> {
     private final ArrayList<Song> mSongList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private Cursor mCursor;
-
-    /**
      * Constructor of <code>LastAddedHandler</code>
      *
      * @param context The {@link Context} to use.
@@ -59,45 +54,45 @@ public class LastAddedLoader extends SectionCreator.SimpleListLoader<Song> {
     @Override
     public List<Song> loadInBackground() {
         // Create the xCursor
-        mCursor = makeLastAddedCursor(getContext());
+        Cursor cursor = makeLastAddedCursor(getContext());
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the song Id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the song name
-                final String songName = mCursor.getString(1);
+                final String songName = cursor.getString(1);
 
                 // Copy the artist name
-                final String artist = mCursor.getString(2);
+                final String artist = cursor.getString(2);
 
                 // Copy the album id
-                final long albumId = mCursor.getLong(3);
+                final long albumId = cursor.getLong(3);
 
                 // Copy the album name
-                final String album = mCursor.getString(4);
+                final String album = cursor.getString(4);
 
                 // Copy the duration
-                final long duration = mCursor.getLong(5);
+                final long duration = cursor.getLong(5);
 
                 // Convert the duration into seconds
                 final int durationInSecs = (int) duration / 1000;
 
                 // Grab the Song Year
-                final int year = mCursor.getInt(6);
+                final int year = cursor.getInt(6);
 
                 // Create a new song
                 final Song song = new Song(id, songName, artist, album, albumId, durationInSecs, year);
 
                 // Add everything up
                 mSongList.add(song);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
         return mSongList;
     }

--- a/src/com/cyanogenmod/eleven/loaders/PlaylistLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/PlaylistLoader.java
@@ -42,11 +42,6 @@ public class PlaylistLoader extends WrappedAsyncTaskLoader<List<Playlist>> {
     private final ArrayList<Playlist> mPlaylistList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private Cursor mCursor;
-
-    /**
      * Constructor of <code>PlaylistLoader</code>
      *
      * @param context The {@link Context} to use
@@ -64,15 +59,15 @@ public class PlaylistLoader extends WrappedAsyncTaskLoader<List<Playlist>> {
         makeDefaultPlaylists();
 
         // Create the Cursor
-        mCursor = makePlaylistCursor(getContext());
+        Cursor cursor = makePlaylistCursor(getContext());
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the playlist id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the playlist name
-                final String name = mCursor.getString(1);
+                final String name = cursor.getString(1);
 
                 final int songCount = MusicUtils.getSongCountForPlaylist(getContext(), id);
 
@@ -81,12 +76,12 @@ public class PlaylistLoader extends WrappedAsyncTaskLoader<List<Playlist>> {
 
                 // Add everything up
                 mPlaylistList.add(playlist);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
         return mPlaylistList;
     }

--- a/src/com/cyanogenmod/eleven/loaders/QueueLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/QueueLoader.java
@@ -35,11 +35,6 @@ public class QueueLoader extends WrappedAsyncTaskLoader<List<Song>> {
     private final ArrayList<Song> mSongList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    private NowPlayingCursor mCursor;
-
-    /**
      * Constructor of <code>QueueLoader</code>
      *
      * @param context The {@link Context} to use
@@ -54,45 +49,45 @@ public class QueueLoader extends WrappedAsyncTaskLoader<List<Song>> {
     @Override
     public List<Song> loadInBackground() {
         // Create the Cursor
-        mCursor = new NowPlayingCursor(getContext());
+        NowPlayingCursor cursor = new NowPlayingCursor(getContext());
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the song Id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the song name
-                final String songName = mCursor.getString(1);
+                final String songName = cursor.getString(1);
 
                 // Copy the artist name
-                final String artist = mCursor.getString(2);
+                final String artist = cursor.getString(2);
 
                 // Copy the album id
-                final long albumId = mCursor.getLong(3);
+                final long albumId = cursor.getLong(3);
 
                 // Copy the album name
-                final String album = mCursor.getString(4);
+                final String album = cursor.getString(4);
 
                 // Copy the duration
-                final long duration = mCursor.getLong(5);
+                final long duration = cursor.getLong(5);
 
                 // Convert the duration into seconds
                 final int durationInSecs = (int) duration / 1000;
 
                 // Copy the year
-                final int year = mCursor.getInt(6);
+                final int year = cursor.getInt(6);
 
                 // Create a new song
                 final Song song = new Song(id, songName, artist, album, albumId, durationInSecs, year);
 
                 // Add everything up
                 mSongList.add(song);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
         return mSongList;
     }

--- a/src/com/cyanogenmod/eleven/loaders/SearchLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/SearchLoader.java
@@ -37,9 +37,9 @@ public class SearchLoader extends WrappedAsyncTaskLoader<List<Song>> {
     private final ArrayList<Song> mSongList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
+     * The query
      */
-    private Cursor mCursor;
+    private String mQuery;
 
     /**
      * Constructor of <code>SongLoader</code>
@@ -49,8 +49,7 @@ public class SearchLoader extends WrappedAsyncTaskLoader<List<Song>> {
      */
     public SearchLoader(final Context context, final String query) {
         super(context);
-        // Create the Cursor
-        mCursor = makeSearchCursor(context, query);
+        mQuery = query;
     }
 
     /**
@@ -59,42 +58,43 @@ public class SearchLoader extends WrappedAsyncTaskLoader<List<Song>> {
     @Override
     public List<Song> loadInBackground() {
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        Cursor cursor = makeSearchCursor(getContext(), mQuery);
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the song Id
                 long id = -1;
 
                 // Copy the song name
-                final String songName = mCursor.getString(mCursor
+                final String songName = cursor.getString(cursor
                         .getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE));
 
                 // Check for a song Id
                 if (!TextUtils.isEmpty(songName)) {
-                    id = mCursor.getLong(mCursor
+                    id = cursor.getLong(cursor
                             .getColumnIndexOrThrow(MediaStore.Audio.Media._ID));
                 }
 
                 // Copy the album name
-                final String album = mCursor.getString(mCursor
+                final String album = cursor.getString(cursor
                         .getColumnIndexOrThrow(MediaStore.Audio.Albums.ALBUM));
 
                 // Copy the album id
-                final long albumId = mCursor.getLong(mCursor
+                final long albumId = cursor.getLong(cursor
                         .getColumnIndexOrThrow(MediaStore.Audio.Albums.ALBUM_ID));
 
                 // Check for a album Id
                 if (id < 0 && !TextUtils.isEmpty(album)) {
-                    id = mCursor.getLong(mCursor
+                    id = cursor.getLong(cursor
                             .getColumnIndexOrThrow(MediaStore.Audio.Albums._ID));
                 }
 
                 // Copy the artist name
-                final String artist = mCursor.getString(mCursor
+                final String artist = cursor.getString(cursor
                         .getColumnIndexOrThrow(MediaStore.Audio.Artists.ARTIST));
 
                 // Check for a artist Id
                 if (id < 0 && !TextUtils.isEmpty(artist)) {
-                    id = mCursor.getLong(mCursor
+                    id = cursor.getLong(cursor
                             .getColumnIndexOrThrow(MediaStore.Audio.Artists._ID));
                 }
 
@@ -103,12 +103,12 @@ public class SearchLoader extends WrappedAsyncTaskLoader<List<Song>> {
 
                 // Add everything up
                 mSongList.add(song);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
         return mSongList;
     }

--- a/src/com/cyanogenmod/eleven/loaders/SongLoader.java
+++ b/src/com/cyanogenmod/eleven/loaders/SongLoader.java
@@ -45,11 +45,6 @@ public class SongLoader extends SectionCreator.SimpleListLoader<Song> {
     protected ArrayList<Song> mSongList = Lists.newArrayList();
 
     /**
-     * The {@link Cursor} used to run the query.
-     */
-    protected Cursor mCursor;
-
-    /**
      * Additional selection filter
      */
     protected String mSelection;
@@ -77,50 +72,50 @@ public class SongLoader extends SectionCreator.SimpleListLoader<Song> {
     @Override
     public List<Song> loadInBackground() {
         // Create the Cursor
-        mCursor = getCursor();
+        Cursor cursor = getCursor();
 
         // Gather the data
-        if (mCursor != null && mCursor.moveToFirst()) {
+        if (cursor != null && cursor.moveToFirst()) {
             do {
                 // Copy the song Id
-                final long id = mCursor.getLong(0);
+                final long id = cursor.getLong(0);
 
                 // Copy the song name
-                final String songName = mCursor.getString(1);
+                final String songName = cursor.getString(1);
 
                 // Copy the artist name
-                final String artist = mCursor.getString(2);
+                final String artist = cursor.getString(2);
 
                 // Copy the album id
-                final long albumId = mCursor.getLong(3);
+                final long albumId = cursor.getLong(3);
 
                 // Copy the album name
-                final String album = mCursor.getString(4);
+                final String album = cursor.getString(4);
 
                 // Copy the duration
-                final long duration = mCursor.getLong(5);
+                final long duration = cursor.getLong(5);
 
                 // Convert the duration into seconds
                 final int durationInSecs = (int) duration / 1000;
 
                 // Copy the Year
-                final int year = mCursor.getInt(6);
+                final int year = cursor.getInt(6);
 
                 // Create a new song
                 final Song song = new Song(id, songName, artist, album, albumId,
                                             durationInSecs, year);
 
-                if (mCursor instanceof SortedCursor) {
-                    song.mBucketLabel = (String)((SortedCursor)mCursor).getExtraData();
+                if (cursor instanceof SortedCursor) {
+                    song.mBucketLabel = (String)((SortedCursor)cursor).getExtraData();
                 }
 
                 mSongList.add(song);
-            } while (mCursor.moveToNext());
+            } while (cursor.moveToNext());
         }
         // Close the cursor
-        if (mCursor != null) {
-            mCursor.close();
-            mCursor = null;
+        if (cursor != null) {
+            cursor.close();
+            cursor = null;
         }
 
         return mSongList;


### PR DESCRIPTION
If we call loadInBackground() twice we will have conflicts since
the two threads will share the cursor. The cursor is only used by
loadInBackground(), there's no need to have a class member for it,
so just keep it in a local variable to prevent conflicts.

BUGBASH-1045

Change-Id: Id484bee852d886c3a49ec8c84ef821f969db9a54