### PR TITLE
Eleven: Fix crash after receiving media button intent

### DIFF
--- a/src/org/lineageos/eleven/MediaButtonIntentReceiver.java
+++ b/src/org/lineageos/eleven/MediaButtonIntentReceiver.java
@@ -76,6 +76,6 @@ public class MediaButtonIntentReceiver extends WakefulBroadcastReceiver {
         i.putExtra(MusicPlaybackService.CMDNAME, command);
         i.putExtra(MusicPlaybackService.FROM_MEDIA_BUTTON, true);
         i.putExtra(MusicPlaybackService.TIMESTAMP, timestamp);
-        startWakefulService(context, i);
+        context.startForegroundService(i);
     }
 }


### PR DESCRIPTION
* Since eleven is not allowed to launch background services
  we need to use ctx.startForegroundService().

Change-Id: Id8eea0f43c3fec982dc14ee289229793ab908739